### PR TITLE
Add notebook destination for jh.

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-configmap.yaml
@@ -11,6 +11,7 @@ data:
   jupyterhub_admins: "admin"
   gpu_mode: ""
   singleuser_pvc_size: 16Gi
+  notebook_destination: "$(notebook_destination)"
 
 ---
 apiVersion: v1


### PR DESCRIPTION
In the odh 1.1.1 release a required parameter notebook_destination was added which needed to be present in the jupyterhub-cfg