### PR TITLE
Added  gpu node toleration to  default type 

### DIFF
--- a/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
+++ b/jupyterhub/jupyterhub/base/jupyterhub-singleuser-profiles-configmap.yaml
@@ -66,3 +66,9 @@ data:
                 spark_image: 'quay.io/radanalyticsio/openshift-spark-py36:2.4.5-2'
               return:
                 SPARK_CLUSTER: 'metadata.name'
+        gpuTypes:
+        - type: default
+          node_tolerations:
+            - key: nvidia.com/gpu
+              operator: "Exists"
+              effect: NoSchedule


### PR DESCRIPTION
Added GPU toleration definition to allow scheduling jupyter notebooks to GPU enabled nodes . Part of https://github.com/os-climate/os_c_data_commons/issues/96