### PR TITLE
adding basic CI files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,25 @@
+repos:
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.1.9
+    hooks:
+      - id: remove-tabs
+
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.3.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-merge-conflict
+      - id: end-of-file-fixer
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-json
+      - id: check-symlinks
+      - id: detect-private-key
+
+  - repo: https://github.com/adrienverge/yamllint.git
+    rev: v1.25.0
+    hooks:
+      - id: yamllint
+        files: \.(yaml|yml)$
+        types: [file, yaml]
+        entry: yamllint --strict -c yamllint-config.yaml

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,20 @@
+presubmits:
+  - name: pre-commit
+    decorate: true
+    skip_report: false
+    always_run: true
+    context: pre-commit
+    spec:
+      containers:
+        - image: quay.io/thoth-station/thoth-precommit-py38:v0.12.5
+          command:
+            - "pre-commit"
+            - "run"
+            - "--all-files"
+          resources:
+            requests:
+              memory: "500Mi"
+              cpu: "300m"
+            limits:
+              memory: "1Gi"
+              cpu: "300m"

--- a/yamllint-config.yaml
+++ b/yamllint-config.yaml
@@ -1,0 +1,11 @@
+---
+extends: default
+rules:
+  line-length: disable
+  document-start: disable
+  indentation:
+    indent-sequences: whatever
+  hyphens:
+    max-spaces-after: 4
+ignore: |
+  *.enc.yaml


### PR DESCRIPTION
Basic CI files have been replicated from operate-first/apps.
os-climate/osc-trino-acl-dsl check was dropped, because it will remain with Kfdefs in operate-first/apps.

Pull-requests made against this repo should be linted as yaml, and ran with pre-commit.