### PR TITLE
fixing permissions with operate-first/odh-manifests fork

### DIFF
--- a/.thoth.yaml
+++ b/.thoth.yaml
@@ -2,10 +2,11 @@ managers:
   - name: version
     configuration:
       maintainers:
-        - crobby
-        - vpavlin
-        - lavlas
-        - nakfour
+        - 4n4nd
+        - Gkrumbach07
+        - Gregory-Pereira
+        - harshad16
+        - HumairAK
       assignees:
         - sesheta
       labels: [bot]

--- a/OWNERS
+++ b/OWNERS
@@ -1,14 +1,12 @@
 # Each list is sorted alphabetically, additions should maintain that order
 approvers:
-- anishasthana
-- crobby
-- lavlas
-- nakfour
-- vpavlin
+- 4n4nd
+- harshad16
+- HumairAK
 
 reviewers:
-- anishasthana
-- crobby
-- lavlas
-- nakfour
-- vpavlin
+- 4n4nd
+- Gkrumbach07
+- Gregory-Pereira
+- harshad16
+- HumairAK


### PR DESCRIPTION
Everyone need privileges to be able to create branches, which I think is done at a repository level, but should approvers be  based on WG / Sig permissions instead? Regardless it will continue to suggest review / block pulls unless we set ourselves as owners of the `operate-first/odh-manifests` fork.