### PR TITLE
Update trino to 373.

### DIFF
--- a/trino/base/kustomization.yaml
+++ b/trino/base/kustomization.yaml
@@ -135,5 +135,5 @@ images:
     newName: quay.io/cloudservices/ubi-hive
     newTag: 2.3.3-002
   - name: trino
-    newName: quay.io/opendatahub/trino
-    newTag: '371'
+    newName: quay.io/os-climate/trino
+    newTag: '373'


### PR DESCRIPTION
OSC-CL2 cluster trino upgrade

Related: https://github.com/operate-first/apps/issues/1843