### PR TITLE
Update trino to 373.

### DIFF
--- a/trino/base/kustomization.yaml
+++ b/trino/base/kustomization.yaml
@@ -136,4 +136,4 @@ images:
     newTag: 2.3.3-002
   - name: trino
     newName: quay.io/opendatahub/trino
-    newTag: '371'
+    newTag: '373'


### PR DESCRIPTION
OSC-CL1 cluster trino upgrade

Related: https://github.com/operate-first/apps/issues/1843