### PR TITLE
fix(byon): Switch ODH Dashboard image to our own

### DIFF
--- a/odh-dashboard/base/deployment.yaml
+++ b/odh-dashboard/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccount: odh-dashboard
       containers:
       - name: odh-dashboard
-        image: quay.io/opendatahub/odh-dashboard:latest-byon
+        image: quay.io/operate-first/odh-dashboard:byon
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
Due to https://github.com/open-services-group/byon/issues/20#issuecomment-1096375547 switching to our own manual builds for now.