### PR TITLE
fix(byon): Openshift pipelines for OCP 4.8 doesn't assume default string type (4.9 does)

### DIFF
--- a/jupyterhub/jupyterhub/overlays/byon/byon-import-jupyterhub-image.yaml
+++ b/jupyterhub/jupyterhub/overlays/byon/byon-import-jupyterhub-image.yaml
@@ -77,6 +77,7 @@ spec:
       taskSpec:
         params:
           - name: url
+            type: string
         workspaces:
           - name: data
         steps:


### PR DESCRIPTION
Backwards compatibility for OCP 4.8