### PR TITLE
Update how monitoring config is managed in trino.

### DIFF
--- a/trino/base/kustomization.yaml
+++ b/trino/base/kustomization.yaml
@@ -13,7 +13,6 @@ resources:
 - hadoop-config.yaml
 - hive-config.yaml
 - hive-jmx-config.yaml
-- trino-config-monitoring-secret.yaml
 - trino-coordinator-dc.yaml
 - trino-service.yaml
 - trino-route.yaml

--- a/trino/base/trino-coordinator-dc.yaml
+++ b/trino/base/trino-coordinator-dc.yaml
@@ -35,12 +35,12 @@ spec:
             name: kafka-table-description-dir
             defaultMode: 420
         - name: prometheus-exporter
-          secret:
-            secretName: trino-config-monitoring
+          configMap:
+            name: trino-config-monitoring
             defaultMode: 420
             items:
-              - key: config.yaml
-                path: config.yaml
+              - key: monitoring-config.yaml
+                path: monitoring-config.yaml
         - name: trino-secret-files
           secret:
             secretName: trino-secret-files
@@ -64,6 +64,8 @@ spec:
                   fieldPath: metadata.uid
           ports:
             - containerPort: 8080
+              protocol: TCP
+            - containerPort: 8082
               protocol: TCP
           volumeMounts:
             - name: trino-config-volume

--- a/trino/base/trino-worker-dc.yaml
+++ b/trino/base/trino-worker-dc.yaml
@@ -35,6 +35,13 @@ spec:
           secret:
             secretName: trino-secret-files
             defaultMode: 420
+        - name: prometheus-exporter
+          configMap:
+            name: trino-config-monitoring
+            defaultMode: 420
+            items:
+              - key: monitoring-config.yaml
+                path: monitoring-config.yaml
       containers:
         - resources:
             requests:
@@ -55,6 +62,8 @@ spec:
           ports:
             - containerPort: 8080
               protocol: TCP
+            - containerPort: 8082
+              protocol: TCP
           volumeMounts:
             - name: trino-config-volume
               mountPath: /etc/trino
@@ -62,6 +71,8 @@ spec:
               mountPath: /etc/trino/catalog
             - name: trino-secret-files
               mountPath: /etc/trino/secrets
+            - name: prometheus-exporter
+              mountPath: /etc/trino/prometheus
           image: trino
           envFrom:
             - secretRef:


### PR DESCRIPTION
This change will allow us to  monitor metrics from trino workers and manage these configs via argocd, not via odh.