### PR TITLE
[odh-cl1] Deploy the current dev version of the odh-dashboard

### DIFF
--- a/odh-dashboard/base/deployment.yaml
+++ b/odh-dashboard/base/deployment.yaml
@@ -27,7 +27,7 @@ spec:
       serviceAccount: odh-dashboard
       containers:
       - name: odh-dashboard
-        image: quay.io/operate-first/odh-dashboard:byon
+        image: quay.io/thoth-station/odh-dashboard:dev
         imagePullPolicy: Always
         ports:
         - containerPort: 8080


### PR DESCRIPTION
OpenDataHub's _Bring-your-own-notebook (BYON)__ functionality development continues into _Custom Notebook Images (CNBi)_.

The current development happens in the [thoth-station org](https://github.com/thoth-station/odh-dashboard).

This PR is to point the deployment to the dev tag coming from the thoth-station/odh-dashboard repo into the staging namespace.