### PR TITLE
[osc-cl1-byon] Point the dashboard to the odh-admin group

### DIFF
--- a/odh-dashboard/overlays/odhdashboardconfig/odh-dashboard-config.yaml
+++ b/odh-dashboard/overlays/odhdashboardconfig/odh-dashboard-config.yaml
@@ -41,5 +41,5 @@ spec:
         cpu: "4"
         memory: 4Gi
   groupsConfig:
-    adminGroups: 'odh-admins'
+    adminGroups: 'odh-admin'
     allowedGroups: 'system:authenticated'


### PR DESCRIPTION
The group of ODH admininistrators managed by operate-first is called [odh-admin](https://github.com/operate-first/apps/blob/2640e3b50596e878261ee825ae4b6910c6ce1fa2/cluster-scope/overlays/prod/osc/osc-cl1/groups/odh-admin.yaml) (without the s).