### PR TITLE
Update the dev version of the CNBi dashboard

### DIFF
--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -17,4 +17,4 @@ resources:
 images:
 - name: odh-dashboard
   newName: quay.io/thoth-station/odh-dashboard
-  newTag: dev
+  newTag: cnbi-v0.1.0


### PR DESCRIPTION
This is to deploy the latest (dev) [version](https://github.com/thoth-station/odh-dashboard/tree/cnbi-v0.1.0) of the ODH dashboard with a CNBi interface to the byon stage namespace.

