### PR TITLE
Add role for CNBi access from the ODH dashboard in OSC cl1

### DIFF
--- a/odh-dashboard/base/role.yaml
+++ b/odh-dashboard/base/role.yaml
@@ -122,3 +122,15 @@ rules:
       - console.openshift.io
     resources:
       - odhquickstarts
+  - apiGroups:
+      - meteor.zone
+    resources:
+      - customruntimeenvironments
+    verbs:
+      - get
+      - list
+      - watch
+      - create
+      - update
+      - patch
+      - delete


### PR DESCRIPTION
The ODH dashboard in the BYON/CNBi staging environment in OSC cl1 should have access to meteor-operator's new Custom Runtime Environment resources.

This PR updates the role to allow that.