### PR TITLE
Update the CNBi version of the odh dashboard to v0.2.0

### DIFF
--- a/odh-dashboard/base/kustomization.yaml
+++ b/odh-dashboard/base/kustomization.yaml
@@ -18,4 +18,4 @@ resources:
 images:
 - name: odh-dashboard
   newName: quay.io/thoth-station/odh-dashboard
-  newTag: cnbi-v0.1.0
+  newTag: cnbi-v0.2.0


### PR DESCRIPTION
The development version of the odh dashboard with custom notebook images has just been tagged with a new version: [cnbi-v0.2.0](https://github.com/thoth-station/odh-dashboard/releases/tag/cnbi-v0.2.0)

This is to update the deployment of that odh-dashboard version.